### PR TITLE
Fix missing reject in `copyFile`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -30,7 +30,7 @@ exports.cp = async function cp(src, dest) {
 }
 
 exports.copyFile = async function copyFile(src, dest) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     fs.copyFile(src, dest, (err) => {
       err ? reject(err) : resolve()
     })


### PR DESCRIPTION
Got the error below, this PR should fix

```
> Task :react-native-bare-kit:link FAILED
/Users/didericis/Code/yt-dlp-proxy/bare-expo/node_modules/bare-link/lib/fs.js:35
      err ? reject(err) : resolve()
      ^

ReferenceError: reject is not defined
    at /Users/didericis/Code/yt-dlp-proxy/bare-expo/node_modules/bare-link/lib/fs.js:35:7
    at FSReqCallback.oncomplete (node:fs:187:23)
```