### PR TITLE
Default --host to the current platform-arch

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -22,7 +22,7 @@ const cmd = command(
     const { entry = '.' } = cmd.args
     const {
       version,
-      host: hosts,
+      host: hosts = [`${process.platform}-${process.arch}`],
       out,
       preset,
       sign,


### PR DESCRIPTION
Without `--host` or `--preset`, `bare-link` linked nothing and exited 0 - a silent no-op. `bare-pack` already defaults its `--host` to `${process.platform}-${process.arch}`; this brings `bare-link`'s CLI in line so running it bare (no flags) links for the current host.

The default lives in `bin.js` only, matching bare-pack (the `link()` API still takes explicit `hosts`). A preset or explicit `--host` overrides it as before.